### PR TITLE
fix: rebase plan conventions and prevent nested agent spawning

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "graph-flow",
   "description": "Planning stack, workflow checkpoints, knowledge graph, and GitHub automation for Claude Code",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": {
     "name": "rollercoaster.dev"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "graph-flow",
   "description": "Planning stack, workflow checkpoints, knowledge graph, and GitHub automation for Claude Code",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "author": {
     "name": "rollercoaster.dev"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "graph-flow",
   "description": "Planning stack, workflow checkpoints, knowledge graph, and GitHub automation for Claude Code",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "author": {
     "name": "rollercoaster.dev"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "graph-flow",
   "description": "Planning stack, workflow checkpoints, knowledge graph, and GitHub automation for Claude Code",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "author": {
     "name": "rollercoaster.dev"
   },

--- a/agents/issue-researcher.md
+++ b/agents/issue-researcher.md
@@ -175,12 +175,12 @@ Before creating any plan, check the **target project's** rules and docs for plan
    If a directory exists with plans in it, that's the project's convention.
 
 4. **Graph-flow fallback:**
-   - If none of the above defines a convention, use the graph-flow default dev-plan directory with the standard `issue-<number>.md` filename
+   - If none of the above defines a convention, use the graph-flow default dev-plan directory with the standard `issue-<number>-<short-desc>.md` filename
 
 **Result: set these values before writing anything:**
 
 - `plan_dir`: directory selected by the precedence rules above
-- `plan_filename`: use the project's documented naming convention, otherwise `issue-<number>.md`
+- `plan_filename`: use the project's documented naming convention, otherwise `issue-<number>-<short-desc>.md`
 - `plan_path`: `<plan_dir>/<plan_filename>`
 - `plan_template`: project template if documented, otherwise the default graph-flow template
 

--- a/agents/issue-researcher.md
+++ b/agents/issue-researcher.md
@@ -30,7 +30,7 @@ model: sonnet
 
 ### Side Effects
 
-- Creates the development plan at the discovered `plan_path` using project conventions or the graph-flow fallback
+- Creates dev plan (path determined by host project conventions, see below)
 - Logs plan creation to checkpoint (if workflow_id provided)
 
 ### Checkpoint Actions Logged
@@ -352,9 +352,9 @@ See `.claude/skills/board-manager/SKILL.md` for command reference and IDs.
 ### Phase 7: Save and Report
 
 1. **Save development plan:**
-   - Write to `plan_path` (from Phase 1.8 discovery)
-   - If the project rule specifies a different naming convention, encode that in `plan_filename` before writing
-   - If using a project-specific template (from Phase 1.8), ensure the plan follows it
+   - Check the host project's CLAUDE.md or planning rules for a preferred plan directory (e.g., `docs/exec-plans/`, `docs/plans/`)
+   - If a convention exists, follow it — use the project's naming pattern and template
+   - If no convention exists, write to `docs/dev-plans/issue-<number>.md`
 
 2. **Report summary:**
    - Key findings

--- a/agents/issue-researcher.md
+++ b/agents/issue-researcher.md
@@ -252,7 +252,9 @@ These inform the research phase and help the plan align with the project's exist
 
 ### Phase 4: Create Development Plan
 
-Generate a detailed plan document:
+Generate a detailed plan document.
+
+**File naming:** `issue-<number>-<short-desc>.md` (e.g., `issue-42-add-jwks-endpoint.md`) for findability. Use lowercase kebab-case for the short description (2-4 words from the issue title).
 
 ```markdown
 # Development Plan: Issue #<number>
@@ -263,6 +265,16 @@ Generate a detailed plan document:
 **Type**: <feature|bug|enhancement|refactor>
 **Complexity**: <TRIVIAL|SMALL|MEDIUM|LARGE>
 **Estimated Lines**: ~<n> lines
+
+## Intent Verification
+
+Observable criteria derived from the issue. These describe what success looks like from a user/system perspective — not generic checklists.
+
+- [ ] <When [actor] does [action], [observable result]>
+- [ ] <[System/component] [behaves in specific way] under [condition]>
+- [ ] <[Metric/output] meets [specific threshold/format]>
+
+_Write criteria that a reviewer could verify by running the code or reading tests. Avoid generic items like "tests pass" — those are assumed._
 
 ## Dependencies
 
@@ -275,6 +287,14 @@ Generate a detailed plan document:
 ## Objective
 
 <What this PR will accomplish>
+
+## Decisions
+
+Architectural and implementation choices made during research. Populated when the researcher encounters multiple valid approaches.
+
+| ID | Decision | Alternatives Considered | Rationale |
+|----|----------|------------------------|-----------|
+| D1 | <what was decided> | <other options> | <why this choice> |
 
 ## Affected Areas
 
@@ -289,8 +309,8 @@ Generate a detailed plan document:
 **Commit**: `<type>(<scope>): <message>`
 **Changes**:
 
-- <specific change>
-- <specific change>
+- [ ] <specific change>
+- [ ] <specific change>
 
 ### Step 2: <description>
 
@@ -302,17 +322,23 @@ Generate a detailed plan document:
 - [ ] Integration tests for <flow>
 - [ ] Manual testing: <steps>
 
-## Definition of Done
+## Not in Scope
 
-- [ ] All implementation steps complete
-- [ ] Tests passing
-- [ ] Type-check passing
-- [ ] Lint passing
-- [ ] Ready for PR
+Items explicitly deferred from this issue. Helps prevent scope creep during implementation.
 
-## Notes
+| Item | Reason | Follow-up |
+|------|--------|-----------|
+| <deferred item> | <why not now> | <issue # or "none"> |
 
-<Any considerations, risks, or questions>
+_If nothing is deferred, write "No items deferred."_
+
+## Discovery Log
+
+Runtime discoveries made during implementation. Starts empty — populated by the implement skill as work progresses.
+
+<!-- Entries added by implement skill:
+- [YYYY-MM-DD HH:MM] <discovery description>
+-->
 ```
 
 ### Phase 5: Validate Plan
@@ -354,7 +380,7 @@ See `.claude/skills/board-manager/SKILL.md` for command reference and IDs.
 1. **Save development plan:**
    - Check the host project's CLAUDE.md or planning rules for a preferred plan directory (e.g., `docs/exec-plans/`, `docs/plans/`)
    - If a convention exists, follow it — use the project's naming pattern and template
-   - If no convention exists, write to `docs/dev-plans/issue-<number>.md`
+   - If no convention exists, write to `docs/dev-plans/issue-<number>-<short-desc>.md`
 
 2. **Report summary:**
    - Key findings

--- a/agents/issue-researcher.md
+++ b/agents/issue-researcher.md
@@ -189,7 +189,7 @@ Before creating any plan, check the **target project's** rules and docs for plan
 | Project rule found with explicit path | Use the path from the rule | Use template from rule if provided |
 | `docs/exec-plans/` exists | `docs/exec-plans/` | Use project's template if documented |
 | `docs/plans/` exists | `docs/plans/` | Default graph-flow template |
-| Nothing found | `.claude/dev-plans/` (graph-flow default) | Default graph-flow template |
+| Nothing found | `docs/dev-plans/` (graph-flow default) | Default graph-flow template |
 
 The final plan must be written to `plan_path`, and `plan_path` must be returned in the agent output exactly as written. Downstream workflows consume that value directly; they must not infer the location themselves.
 

--- a/commands/auto-issue.md
+++ b/commands/auto-issue.md
@@ -220,8 +220,7 @@ The issue-researcher will:
 - Discover the project's plan conventions (location, template) from `.claude/rules/`, `CLAUDE.md`, or existing plan directories
 - Analyze codebase using Glob, Grep, Read
 - Check dependencies
-- Create the development plan at the discovered location, using the graph-flow fallback only when the project does not define its own convention
-- Return the exact `plan_path` to the saved plan; do not infer or reconstruct it in later phases
+- Create dev plan (path follows host project conventions, default: `docs/dev-plans/issue-<N>.md`)
 
 **If `--dry-run`:** Stop here, display plan, exit.
 
@@ -297,7 +296,6 @@ Skill(finalize):
 The finalize skill will:
 
 - Run final validation
-- Clean up the discovered plan file at the exact `plan_path` from Phase 2, if the workflow created one
 - Push branch
 - Create PR
 - Update board to "Blocked"

--- a/commands/auto-issue.md
+++ b/commands/auto-issue.md
@@ -234,7 +234,7 @@ The issue-researcher will:
 - Discover the project's plan conventions (location, template) from `.claude/rules/`, `CLAUDE.md`, or existing plan directories
 - Analyze codebase using Glob, Grep, Read
 - Check dependencies
-- Create dev plan (path follows host project conventions, default: `docs/dev-plans/issue-<N>.md`)
+- Create dev plan (path follows host project conventions, default: `docs/dev-plans/issue-<number>-<short-desc>.md`)
 
 **If `--dry-run`:** Stop here, display plan, exit.
 
@@ -274,7 +274,7 @@ Skill(review):
 The review skill will:
 
 - Run `/simplify` for code quality, reuse, and efficiency improvements
-- Spawn review agents in parallel (as Task subagents)
+- Spawn standalone background review agents in parallel (do not pass team_name)
 - Classify findings by severity
 - Auto-fix critical findings (up to 3 attempts each)
 - Return summary with unresolved findings

--- a/commands/auto-issue.md
+++ b/commands/auto-issue.md
@@ -56,12 +56,14 @@ WRONG understanding:
 
 **CRITICAL: When this workflow runs inside a team worker, sub-agents MUST NOT join the team.**
 
-All Agent/Task calls in this workflow (issue-researcher, review agents, auto-fixer) are internal implementation details — they should be standalone background agents, not team members.
+All **Agent** calls in this workflow (issue-researcher, review agents, auto-fixer) are internal implementation details — they should be standalone background agents, not team members.
 
 **Rules for all Agent calls in this workflow:**
 - **Never** pass `team_name` to Agent calls
 - Always use `run_in_background: true` for sub-agents
 - The team lead should only see the worker running this workflow, not its internal sub-agents
+
+These rules are **Agent-only**. `Task` calls use a different API and do not accept `team_name` or `run_in_background` — do not apply these options to Task.
 
 This prevents zombie agents that the team lead can't control and eliminates idle notification noise from internal sub-agents.
 

--- a/commands/auto-issue.md
+++ b/commands/auto-issue.md
@@ -52,15 +52,28 @@ WRONG understanding:
 /auto-issue 123 --visual --figma-url https://figma.com/design/...
 ```
 
+## Team Isolation
+
+**CRITICAL: When this workflow runs inside a team worker, sub-agents MUST NOT join the team.**
+
+All Agent/Task calls in this workflow (issue-researcher, review agents, auto-fixer) are internal implementation details — they should be standalone background agents, not team members.
+
+**Rules for all Agent calls in this workflow:**
+- **Never** pass `team_name` to Agent calls
+- Always use `run_in_background: true` for sub-agents
+- The team lead should only see the worker running this workflow, not its internal sub-agents
+
+This prevents zombie agents that the team lead can't control and eliminates idle notification noise from internal sub-agents.
+
 ## Workflow
 
 ```text
 Phase 1:   Setup          → Skill(setup)
 Phase 1.5: Visual Design  → Skill(visual-test, { mode: "design" })   [if --visual]
 Phase 1.6: Visual Before  → Skill(visual-test, { mode: "before" })   [if --visual]
-Phase 2:   Research        → Task(issue-researcher)
+Phase 2:   Research        → Agent(issue-researcher) [standalone, no team_name]
 Phase 3:   Implement       → Skill(implement)
-Phase 4:   Review          → Skill(review)
+Phase 4:   Review          → Skill(review) [internally spawns standalone agents]
 Phase 4.5: Visual After    → Skill(visual-test, { mode: "after" })   [if --visual]
 Phase 5:   Finalize        → Skill(finalize)
 ```
@@ -210,9 +223,10 @@ Store screenshot paths in workflow state for the finalize phase.
 ## Phase 2: Research
 
 ```text
-Task(issue-researcher):
+Agent(issue-researcher):
   Input:  { issue_number: <N> }
   Output: { plan_path, complexity, commit_count }
+  Options: { run_in_background: true }  # standalone — no team_name
 ```
 
 The issue-researcher will:

--- a/commands/work-on-issue.md
+++ b/commands/work-on-issue.md
@@ -183,8 +183,7 @@ The issue-researcher will:
 - Discover the project's plan conventions (location, template) from `.claude/rules/`, `CLAUDE.md`, or existing plan directories
 - Analyze codebase using Glob, Grep, Read
 - Check dependencies
-- Create the development plan at the discovered location, using the graph-flow fallback only when the project does not define its own convention
-- Return the exact `plan_path` to the saved plan so Gate 2 and Phase 3 use the same artifact
+- Create dev plan (path follows host project conventions, default: `docs/dev-plans/issue-<N>.md`)
 
 ---
 
@@ -307,7 +306,6 @@ Skill(finalize):
 The finalize skill will:
 
 - Run final validation
-- Clean up the discovered plan file at the exact `plan_path` from Phase 2, if the workflow created one
 - Push branch
 - Create PR
 - Update board to "Blocked"

--- a/commands/work-on-issue.md
+++ b/commands/work-on-issue.md
@@ -221,6 +221,7 @@ Skill(implement):
 
 The implement skill handles the full implementation cycle with per-commit gates:
 
+- Reads the development plan from the `plan_path` returned by Phase 2
 - Makes changes per plan step
 - Runs validation (type-check, lint)
 - Shows diff and proposed commit message at each gate

--- a/commands/work-on-issue.md
+++ b/commands/work-on-issue.md
@@ -183,7 +183,7 @@ The issue-researcher will:
 - Discover the project's plan conventions (location, template) from `.claude/rules/`, `CLAUDE.md`, or existing plan directories
 - Analyze codebase using Glob, Grep, Read
 - Check dependencies
-- Create dev plan (path follows host project conventions, default: `docs/dev-plans/issue-<N>.md`)
+- Create dev plan (path follows host project conventions, default: `docs/dev-plans/issue-<number>-<short-desc>.md`)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-flow",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-flow",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-flow",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-flow",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/skills/auto-issue/SKILL.md
+++ b/skills/auto-issue/SKILL.md
@@ -73,9 +73,7 @@ Store screenshot paths in workflow state. Both calls are best-effort — if skip
 
 ### Phase 2: Research
 
-Run issue analysis with the issue-researcher agent using `Task`. The researcher discovers the project's plan conventions (Phase 1.8 in the researcher workflow) and saves the plan at the appropriate location, using the project-configured plan directory when one exists and otherwise falling back to the graph-flow default convention.
-
-Capture `plan_path` from the researcher output and pass that exact value through the rest of the workflow. Do not assume or reconstruct a default location.
+Run issue analysis with the issue-researcher agent using `Task`. The researcher determines the plan path based on host project conventions (e.g., `docs/exec-plans/`, `docs/plans/`). Default fallback: `docs/dev-plans/issue-<N>.md`.
 
 If `dry_run=true`, return the plan path and stop.
 

--- a/skills/auto-issue/SKILL.md
+++ b/skills/auto-issue/SKILL.md
@@ -73,7 +73,7 @@ Store screenshot paths in workflow state. Both calls are best-effort — if skip
 
 ### Phase 2: Research
 
-Run issue analysis with the issue-researcher agent using `Task`. The researcher determines the plan path based on host project conventions (e.g., `docs/exec-plans/`, `docs/plans/`). Default fallback: `docs/dev-plans/issue-<number>-<short-desc>.md`.
+Run issue analysis with the issue-researcher agent using the `Agent` tool — standalone (no `team_name`) with `run_in_background: true` to match the nested-agent prevention rules in `commands/auto-issue.md`. The researcher determines the plan path based on host project conventions (e.g., `docs/exec-plans/`, `docs/plans/`). Default fallback: `docs/dev-plans/issue-<number>-<short-desc>.md`.
 
 Capture `plan_path` from the researcher output and pass that exact value through the rest of the workflow.
 

--- a/skills/auto-issue/SKILL.md
+++ b/skills/auto-issue/SKILL.md
@@ -73,7 +73,9 @@ Store screenshot paths in workflow state. Both calls are best-effort — if skip
 
 ### Phase 2: Research
 
-Run issue analysis with the issue-researcher agent using `Task`. The researcher determines the plan path based on host project conventions (e.g., `docs/exec-plans/`, `docs/plans/`). Default fallback: `docs/dev-plans/issue-<N>.md`.
+Run issue analysis with the issue-researcher agent using `Task`. The researcher determines the plan path based on host project conventions (e.g., `docs/exec-plans/`, `docs/plans/`). Default fallback: `docs/dev-plans/issue-<number>-<short-desc>.md`.
+
+Capture `plan_path` from the researcher output and pass that exact value through the rest of the workflow.
 
 If `dry_run=true`, return the plan path and stop.
 

--- a/skills/auto-issue/SKILL.md
+++ b/skills/auto-issue/SKILL.md
@@ -2,6 +2,7 @@
 name: auto-issue
 description: Fully autonomous issue-to-PR workflow. Use when a worker should execute one issue end-to-end without human gates.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Skill, Task
+context: fork
 ---
 
 # Auto-Issue Skill

--- a/skills/finalize/SKILL.md
+++ b/skills/finalize/SKILL.md
@@ -134,6 +134,21 @@ Determine scope from primary package affected.
 
 **Create PR:**
 
+**Read dev plan (if it exists):**
+
+Before creating the PR, look for the dev plan to extract Intent Verification and Decisions:
+
+```bash
+ls docs/dev-plans/issue-*.md docs/plans/issue-*.md docs/exec-plans/issue-*.md 2>/dev/null
+```
+
+If found, extract:
+- **Intent Verification** section (with check status from implementation)
+- **Decisions** table (key architectural choices)
+- **Discovery Log** entries (if any, for notable runtime findings)
+
+**Create PR:**
+
 ```bash
 gh pr create --title "<type>(<scope>): <description> (#<issue_number>)" --body "$(cat <<'PRBODY'
 ## Summary
@@ -143,6 +158,22 @@ gh pr create --title "<type>(<scope>): <description> (#<issue_number>)" --body "
 ## Changes
 
 <bullet list of key changes>
+
+## Intent Verification
+
+<Copy from dev plan with check status. If no plan exists, omit this section.>
+
+- [x] <met criterion>
+- [x] <met criterion>
+- [ ] <unmet criterion, if any — explain why>
+
+## Key Decisions
+
+<Summarize from Decisions table. If no plan or no decisions, omit this section.>
+
+| Decision | Rationale |
+|----------|-----------|
+| <what> | <why> |
 
 ## Test Plan
 

--- a/skills/finalize/SKILL.md
+++ b/skills/finalize/SKILL.md
@@ -149,6 +149,12 @@ If multiple files match, use the one whose filename contains the current issue n
 
 If no plan file exists, omit the Intent Verification and Key Decisions sections from the PR body.
 
+**Extraction logic:**
+
+1. **Intent Verification** — extract every checkbox line (`- [ ]` or `- [x]`) between the `## Intent Verification` heading and the next `##` heading. Preserve check status verbatim.
+2. **Key Decisions** — extract the markdown table under `## Key Decisions` (or `## Decisions`). Skip the header and separator rows; re-emit as a two-column `| Decision | Rationale |` table in the PR body. If the table is empty or absent, omit the section.
+3. **Discovery Log** — extract timestamped entries of the form `- [YYYY-MM-DD HH:MM] <text>` under the `## Discovery Log` heading (entries may be wrapped in an HTML comment block; strip `<!-- … -->` delimiters before parsing). If no entries exist, omit the section from the PR body.
+
 **Create PR:**
 
 ```bash

--- a/skills/finalize/SKILL.md
+++ b/skills/finalize/SKILL.md
@@ -142,10 +142,12 @@ Before creating the PR, look for the dev plan to extract Intent Verification and
 ls docs/dev-plans/issue-*.md docs/plans/issue-*.md docs/exec-plans/issue-*.md 2>/dev/null
 ```
 
-If found, extract:
+If multiple files match, use the one whose filename contains the current issue number. If found, extract:
 - **Intent Verification** section (with check status from implementation)
 - **Decisions** table (key architectural choices)
 - **Discovery Log** entries (if any, for notable runtime findings)
+
+If no plan file exists, omit the Intent Verification and Key Decisions sections from the PR body.
 
 **Create PR:**
 

--- a/skills/finalize/SKILL.md
+++ b/skills/finalize/SKILL.md
@@ -15,7 +15,7 @@ Completes the workflow by creating PR and cleaning up.
 | Field              | Type    | Required | Description                                            |
 | ------------------ | ------- | -------- | ------------------------------------------------------ |
 | `issue_number`     | number  | Yes      | GitHub issue number                                    |
-| `plan_path`        | string  | No       | Exact development plan path to clean up after PR creation |
+| `plan_path`        | string  | No       | Exact development plan path to read for Intent Verification, Decisions, and Discovery Log extraction into the PR body |
 | `findings_summary` | object  | No       | Summary from review phase                              |
 | `force`            | boolean | No       | Create PR even with unresolved issues (default: false) |
 | `skip_board`       | boolean | No       | Skip board update (default: false)                     |
@@ -238,14 +238,6 @@ a-board-update({ issueNumber: <issue_number>, status: "Blocked" })
 ```
 
 **If board update fails:** Log warning, continue.
-
-### Step 5.5: Clean Up Plan File (if plan_path provided)
-
-- Delete the file at the exact `plan_path` passed into this skill.
-- Do not reconstruct a fallback location or infer the path from `issue_number`.
-- If the file is already missing, log a warning and continue.
-
-Callers must pass the exact `plan_path` returned by the research phase so cleanup targets the canonical plan artifact.
 
 ### Step 6: Send Notification (unless skip_notify)
 

--- a/skills/finalize/SKILL.md
+++ b/skills/finalize/SKILL.md
@@ -36,8 +36,7 @@ Completes the workflow by creating PR and cleaning up.
 1. Pushes branch to remote
 2. Creates GitHub PR
 3. Updates board to "Blocked" (awaiting review)
-4. Cleans up the issue's discovered development plan file at `plan_path`, if provided
-5. Sends Telegram notification with PR link
+4. Sends Telegram notification with PR link
 
 ## Prerequisites
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -214,9 +214,27 @@ For each step in the development plan:
      ```markdown
      - [YYYY-MM-DD HH:MM] <what changed and why>
      ```
-     Also log to checkpoint: `c-update` with context describing the deviation
+     Also log to checkpoint with this exact payload:
+     ```
+     c-update({
+       issueNumber,
+       workflowId,
+       type: "deviation",
+       discovery: "<deviation description>",
+       timestamp: "<ISO-8601>"
+     })
+     ```
    - **On new decision:** Add a row to the Decisions table with ID, decision, alternatives, rationale.
-     Also log to checkpoint: `c-update` with the decision in the decisions array
+     Also log to checkpoint with this exact payload:
+     ```
+     c-update({
+       issueNumber,
+       workflowId,
+       type: "decision",
+       decision: { id, decision, alternatives, rationale },
+       timestamp: "<ISO-8601>"
+     })
+     ```
    - **On explicit deferral:** Add to the Not in Scope table with item, reason, and follow-up issue (if any)
 
 ### Phase 3: Handle Deviations

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -274,7 +274,7 @@ After all commits:
    - Read the dev plan's Intent Verification section
    - For each criterion, verify it is met by the implementation
    - Check off met criteria in the plan (change `- [ ]` to `- [x]`)
-   - If any criteria are NOT met, stop and report which ones failed and why
+   - If any criteria are NOT met, report which ones failed and why. In gated workflows (work-on-issue), stop and wait for user approval before continuing. In autonomous workflows (auto-issue), log the gap and proceed
 
 ### Phase 5: Report Completion
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -208,6 +208,17 @@ For each step in the development plan:
    - Show files changed
    - Note any deviations from plan
 
+8. **Update the dev plan (live plan maintenance):**
+   - Check off completed items in the Implementation Plan section (change `- [ ]` to `- [x]`)
+   - **On deviation:** Add a timestamped entry to the Discovery Log section:
+     ```markdown
+     - [YYYY-MM-DD HH:MM] <what changed and why>
+     ```
+     Also log to checkpoint: `c-update` with context describing the deviation
+   - **On new decision:** Add a row to the Decisions table with ID, decision, alternatives, rationale.
+     Also log to checkpoint: `c-update` with the decision in the decisions array
+   - **On explicit deferral:** Add to the Not in Scope table with item, reason, and follow-up issue (if any)
+
 ### Phase 3: Handle Deviations
 
 If the plan needs adjustment:
@@ -258,6 +269,12 @@ After all commits:
    - Is it under ~500 lines?
    - Does each commit stand alone?
    - Is the branch focused?
+
+5. **Verify Intent (plan-aware check):**
+   - Read the dev plan's Intent Verification section
+   - For each criterion, verify it is met by the implementation
+   - Check off met criteria in the plan (change `- [ ]` to `- [x]`)
+   - If any criteria are NOT met, stop and report which ones failed and why
 
 ### Phase 5: Report Completion
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -161,9 +161,8 @@ Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `build`, `ci`
    ```
 
 2. **Load development plan:**
-   - Read from the `plan_path` provided by the caller (required input)
-   - The path is determined by the issue-researcher based on project conventions
-   - Do not reconstruct a fallback path if `plan_path` is missing or different
+   - Read from the path provided by the caller (`plan_path` input)
+   - The researcher agent determines this path based on host project conventions
 
 ### Phase 2: Execute Plan Step by Step
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -83,7 +83,7 @@ Look for the dev plan in the project's plan directory:
 ls docs/dev-plans/issue-*.md docs/plans/issue-*.md docs/exec-plans/issue-*.md 2>/dev/null
 ```
 
-If a plan exists for the current issue:
+If multiple files match, use the one whose filename contains the current issue number. If a plan exists for the current issue:
 1. Read the **Intent Verification** section — these are the success criteria
 2. Read the **Not in Scope** section — these items should NOT have been implemented
 3. Store both for use in the output summary
@@ -257,7 +257,7 @@ NON-CRITICAL (for PR reviewer):
 - [code-reviewer] src/baz.ts:15 - Consider extracting helper (confidence: 72)
 - [test-analyzer] Missing edge case test for empty input (gap: 4)
 
-PLAN COMPLIANCE:
+PLAN COMPLIANCE: (omit section if no plan exists)
 - Intent Verification: <N>/<M> criteria met
 - Scope: clean | scope creep detected (<details if any>)
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -257,9 +257,13 @@ NON-CRITICAL (for PR reviewer):
 - [code-reviewer] src/baz.ts:15 - Consider extracting helper (confidence: 72)
 - [test-analyzer] Missing edge case test for empty input (gap: 4)
 
-PLAN COMPLIANCE: (omit section if no plan exists)
+PLAN COMPLIANCE: (omit entire section if no plan exists)
 - Intent Verification: <N>/<M> criteria met
+  - N = number of plan-specified criteria satisfied by the implementation
+  - M = total criteria listed under "## Intent Verification" in the plan
 - Scope: clean | scope creep detected (<details if any>)
+  - "clean" = no items from "Not in Scope" were implemented AND all changed files fall within the plan's "Affected Areas"
+  - "scope creep detected" = any "Not in Scope" item was implemented, OR files outside "Affected Areas" were changed — list the specific items/files as details
 
 Summary: <unresolved> unresolved critical findings
 ```

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -75,6 +75,19 @@ Additional review agents can be defined in the project's `.claude/agents/` direc
 git diff main --name-only
 ```
 
+**Read dev plan (if it exists):**
+
+Look for the dev plan in the project's plan directory:
+
+```bash
+ls docs/dev-plans/issue-*.md docs/plans/issue-*.md docs/exec-plans/issue-*.md 2>/dev/null
+```
+
+If a plan exists for the current issue:
+1. Read the **Intent Verification** section — these are the success criteria
+2. Read the **Not in Scope** section — these items should NOT have been implemented
+3. Store both for use in the output summary
+
 **Check for project-specific agents:**
 
 ```bash
@@ -241,6 +254,10 @@ UNRESOLVED (require manual attention):
 NON-CRITICAL (for PR reviewer):
 - [code-reviewer] src/baz.ts:15 - Consider extracting helper (confidence: 72)
 - [test-analyzer] Missing edge case test for empty input (gap: 4)
+
+PLAN COMPLIANCE:
+- Intent Verification: <N>/<M> criteria met
+- Scope: clean | scope creep detected (<details if any>)
 
 Summary: <unresolved> unresolved critical findings
 ```

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -2,6 +2,7 @@
 name: review
 description: Coordinates review agents and manages auto-fix loop. Spawns code-reviewer, test-analyzer, silent-failure-hunter in parallel, classifies findings, and attempts fixes for critical issues.
 allowed-tools: Bash, Read, Glob, Grep, Skill, Task
+context: fork
 ---
 
 # Review Skill

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review
 description: Coordinates review agents and manages auto-fix loop. Spawns code-reviewer, test-analyzer, silent-failure-hunter in parallel, classifies findings, and attempts fixes for critical issues.
-allowed-tools: Bash, Read, Glob, Grep, Skill, Task
+allowed-tools: Bash, Read, Glob, Grep, Skill, Agent
 context: fork
 ---
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -39,8 +39,8 @@ Coordinates code review and manages the auto-fix cycle.
 
 ### Side Effects
 
-1. Spawns review agents (parallel or sequential)
-2. Spawns auto-fixer for critical findings
+1. Spawns review agents as standalone background agents (parallel or sequential, never as team members)
+2. Spawns auto-fixer as standalone background agent for critical findings
 3. Creates fix commits
 4. Logs all actions to checkpoint
 
@@ -122,20 +122,22 @@ This complements the review agents which focus on bugs, test gaps, and silent fa
 
 ### Step 2: Spawn Review Agents
 
+**CRITICAL: Team isolation.** All review agents are internal sub-agents — they MUST be spawned as standalone background agents, never as team members. Do NOT pass `team_name` to any Agent call. This prevents zombie team members and idle notification noise when the review skill runs inside a team worker.
+
 **If parallel mode (default):**
 
-Spawn all agents simultaneously using Task tool with multiple calls:
+Spawn all agents simultaneously using the Agent tool with `run_in_background: true` (no `team_name`):
 
 ```text
-Task(pr-review-toolkit:code-reviewer): "Review code changes for issue workflow <workflow_id>"
-Task(pr-review-toolkit:pr-test-analyzer): "Analyze test coverage for changes"
-Task(pr-review-toolkit:silent-failure-hunter): "Check for silent failures in changes"
-Task(openbadges-compliance-reviewer): "Check OB spec compliance" (if badge code AND agent exists in project)
+Agent(pr-review-toolkit:code-reviewer, run_in_background: true): "Review code changes for issue workflow <workflow_id>"
+Agent(pr-review-toolkit:pr-test-analyzer, run_in_background: true): "Analyze test coverage for changes"
+Agent(pr-review-toolkit:silent-failure-hunter, run_in_background: true): "Check for silent failures in changes"
+Agent(openbadges-compliance-reviewer, run_in_background: true): "Check OB spec compliance" (if badge code AND agent exists in project)
 ```
 
 **If sequential mode:**
 
-Spawn each agent one at a time, collecting results.
+Spawn each agent one at a time using the Agent tool (no `team_name`), collecting results.
 
 ### Step 3: Collect and Normalize Findings
 
@@ -170,8 +172,8 @@ attempt = 0
 while not fixed AND attempt < max_retry:
     attempt++
 
-    Spawn auto-fixer:
-    Task(auto-fixer): "Fix: <finding.message> in <finding.file>:<finding.line>"
+    Spawn auto-fixer (standalone — no team_name):
+    Agent(auto-fixer, run_in_background: true): "Fix: <finding.message> in <finding.file>:<finding.line>"
 
     If fix successful:
         finding.fixed = true


### PR DESCRIPTION
## Summary

- Resolves merge conflicts from rebasing plan convention changes onto main
- Respects host project plan conventions, stops deleting dev plans during finalize
- Enriches dev plans with intent verification, decisions, and discovery log sections
- Prevents nested agent spawning in teams via `context:fork`
- Version bumps to 3.2.1

## Changes

- **agents/issue-researcher.md**: Simplified plan path convention wording, added intent verification/decisions/discovery log to plan template
- **commands/auto-issue.md, work-on-issue.md**: Removed plan cleanup references, added team isolation rules
- **skills/auto-issue/SKILL.md**: Concise plan path description
- **skills/finalize/SKILL.md**: Removed plan deletion side effect, added intent verification to PR template
- **skills/implement/SKILL.md**: Live plan maintenance with deviation tracking
- **skills/review/SKILL.md**: Enhanced review workflow

## Test plan

- [ ] Verify plan conventions are respected in host projects
- [ ] Verify dev plans are NOT deleted during finalize
- [ ] Verify nested agent spawning is prevented in team workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR generation now augments bodies with Intent Verification and Key Decisions when a dev plan exists; workflows report plan compliance.

* **Documentation**
  * Expanded development plan templates with Intent Verification, Decisions, Not‑in‑Scope, and Discovery Log sections.
  * Updated workflow docs to prefer discovered/default plan locations and to stop deleting plan files after PR creation.
  * Review/workflow guidance now documents spawning background review agents (isolated from team context).

* **Chores**
  * Updated product version to 3.2.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->